### PR TITLE
Math functions added.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 4
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "terminal-calculator"
 version = "0.5.0"
+dependencies = [
+ "libm",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ name = "calc"
 path = "src/main.rs"
 
 [dependencies]
+libm = "0.2.15"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub enum InputError {
 pub enum EvaluationError {
     DivisionByZero,
     InvalidOperation,
+    NotAFunction,
+    Undefined,
     // InvalidInput,
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,6 +1,13 @@
 use crate::parser::AstNode;
 use crate::errors::EvaluationError;
 
+#[derive(PartialEq, Debug, Clone)]
+pub enum Function {
+    Sin,
+    Cos,
+    Tan,
+}
+
 impl AstNode {
     pub fn evaluate(&self) -> Result<f64, EvaluationError> {
         match self {
@@ -28,6 +35,17 @@ impl AstNode {
                 };
 
                 match operator.apply_binary(a, b) {
+                    Ok(result) => Ok(result),
+                    Err(error) => Err(error),
+                }
+            }
+            AstNode::Function {function, args} => {
+                let a: f64 = match args.evaluate() {
+                    Ok(result) => result,
+                    Err(error) => return Err(error),
+                };
+                
+                match function.apply_function(a) {
                     Ok(result) => Ok(result),
                     Err(error) => Err(error),
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,14 @@ fn evaluate(input: &str, context: &Context) -> () {
                     println!("EvaluationError: Invalid operation.");
                     return;
                 }
+                EvaluationError::NotAFunction => {
+                    println!("EvaluationError: Not a function");
+                    return;
+                }
+                EvaluationError::Undefined => {
+                    println!("EvaluationError: tan(x) is Undefined.");
+                    return;
+                }
                 // EvaluationError::InvalidInput => {
                 //     println!("EvaluationError: Invalid input.");
                 //     return;
@@ -191,6 +199,7 @@ fn print_tokens(tokens: &Vec<Token>) {
         match token.token_type {
             TokenType::Number => println!("Type: Number, Lexeme: {}", token.lexeme),
             TokenType::Identifier => println!("Type: Identifier, Lexeme: {}", token.lexeme),
+            TokenType::Keyword(_) => println!("Type: Keyword, Lexeme: {}", token.lexeme),
 
             // OPERATORS
             TokenType::Negation => println!(

--- a/tests/lexer_tests.rs
+++ b/tests/lexer_tests.rs
@@ -1,4 +1,5 @@
 use terminal_calculator::lexer::{tokenise, Token, TokenType};
+use terminal_calculator::evaluator::Function;
 
 // Tokenises a basic input
 #[test]
@@ -50,6 +51,54 @@ fn test_tokeniser_with_implicit_multiplication() {
         Token { token_type: TokenType::Addition, lexeme: "+".to_string() },
         Token { token_type: TokenType::Number, lexeme: "5".to_string() },
         Token { token_type: TokenType::RightParenthesis, lexeme: ")".to_string() },
+    ];
+    let tokens = match tokenise(input.to_string()) {
+        Ok(result) => result,
+        Err(error) => panic!("LexerError: {:?}", error),
+    };
+    assert_eq!(tokens, expected_tokens);
+}
+
+fn test_tokeniser_function() {
+    let input = "sin(2)";
+    let expected_tokens = vec![
+        Token { token_type: TokenType::Keyword(Function::Sin), lexeme: "sin".to_string() },
+        Token { token_type: TokenType::LeftParenthesis, lexeme: "(".to_string() },
+        Token { token_type: TokenType::Number, lexeme: "2".to_string() },
+        Token { token_type: TokenType::RightParenthesis, lexeme: ")".to_string() },
+    ];
+    let tokens = match tokenise(input.to_string()) {
+        Ok(result) => result,
+        Err(error) => panic!("LexerError: {:?}", error),
+    };
+    assert_eq!(tokens, expected_tokens);
+}
+
+#[test]
+fn test_tokeniser_function_with_implicit_multiplication() {
+    let input = "2cos(0)";
+    let expected_tokens = vec![
+        Token { token_type: TokenType::Number, lexeme: "2".to_string() },
+        Token { token_type: TokenType::Multiplication, lexeme: "*".to_string() },
+        Token { token_type: TokenType::Keyword(Function::Cos), lexeme: "cos".to_string() },
+        Token { token_type: TokenType::LeftParenthesis, lexeme: "(".to_string() },
+        Token { token_type: TokenType::Number, lexeme: "0".to_string() },
+        Token { token_type: TokenType::RightParenthesis, lexeme: ")".to_string() },
+    ];
+    let tokens = match tokenise(input.to_string()) {
+        Ok(result) => result,
+        Err(error) => panic!("LexerError: {:?}", error),
+    };
+    assert_eq!(tokens, expected_tokens);
+}
+
+#[test]
+fn test_tokeniser_identifier_with_implicit_multiplication() {
+    let input = "2x";
+    let expected_tokens = vec![
+        Token { token_type: TokenType::Number, lexeme: "2".to_string() },
+        Token { token_type: TokenType::Multiplication, lexeme: "*".to_string() },
+        Token { token_type: TokenType::Identifier, lexeme: "x".to_string() },
     ];
     let tokens = match tokenise(input.to_string()) {
         Ok(result) => result,

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -186,7 +186,6 @@ fn test_parse_expression_with_exponentiation() {
 
 // Parses an expression with an unexpected token and returns an error, this should not get past the lexer.
 #[test]
-#[should_panic(expected = "LexerError: InvalidToken(\"@\")")]
 fn test_parse_expression_unexpected_token() {
     let input = "3 + 5 @ 2";
     let tokens = match tokenise(input.to_string()) {


### PR DESCRIPTION
**Math functions are now supported!**

## Changes made, broadly:
 - A new public enum called `Function` has been added.
 - A new `TokenType` variant called `Keyword(Function)` has been added
 - A new method on `TokenType`, `apply_function()` has been added
 - A new `AstNode` variant called `Function` has been added.
 - A new `push_word()` method on Vec\<Token> (trait TokenVector) has been added in the lexer, this also separates any leading numbers from the identifier/keyword and inserts a multiplication (`[2x] -> [2] [*] [x]`)
 - Some integration tests have been expanded for the maths functions, unit tests remain though.
 

 *(+ crate) libm*