### PR TITLE
Unit tests and UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,4 +13,11 @@ name = "terminal-calculator"
 version = "0.5.0"
 dependencies = [
  "libm",
+ "unicode-ident",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ path = "src/main.rs"
 
 [dependencies]
 libm = "0.2.15"
+unicode-ident = "1.0.18"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,4 +25,5 @@ pub enum EvaluationError {
 #[derive(Debug, PartialEq)]
 pub enum LexerError {
     InvalidToken(String),
+    InvalidIdentifier(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,10 @@ fn evaluate(input: &str, context: &Context) -> () {
                     println!("LexerError: Invalid token in input: {}", token);
                     return;
                 }
+                LexerError::InvalidIdentifier(identifier) => {
+                    println!("LexerError: Invalid variable name: {}", identifier);
+                    return;
+                }
             }
         }
     };

--- a/tests/lexer_tests.rs
+++ b/tests/lexer_tests.rs
@@ -59,6 +59,7 @@ fn test_tokeniser_with_implicit_multiplication() {
     assert_eq!(tokens, expected_tokens);
 }
 
+#[test]
 fn test_tokeniser_function() {
     let input = "sin(2)";
     let expected_tokens = vec![
@@ -105,4 +106,15 @@ fn test_tokeniser_identifier_with_implicit_multiplication() {
         Err(error) => panic!("LexerError: {:?}", error),
     };
     assert_eq!(tokens, expected_tokens);
+}
+
+// Tokenises an expression with an unexpected token and returns an error.
+#[test]
+#[should_panic(expected = "LexerError: InvalidIdentifier(\"@\")")]
+fn test_tokenise_expression_unexpected_token() {
+    let input = "3 + 5 @ 2";
+    let _tokens = match tokenise(input.to_string()) {
+        Ok(result) => result,
+        Err(error) => panic!("LexerError: {:?}", error),
+    };
 }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -184,19 +184,6 @@ fn test_parse_expression_with_exponentiation() {
     });
 }
 
-// Parses an expression with an unexpected token and returns an error, this should not get past the lexer.
-#[test]
-fn test_parse_expression_unexpected_token() {
-    let input = "3 + 5 @ 2";
-    let tokens = match tokenise(input.to_string()) {
-        Ok(result) => result,
-        Err(error) => panic!("LexerError: {:?}", error),
-    };
-    let ast = construct_ast(&tokens);
-    assert!(ast.is_err());
-    assert_eq!(ast.unwrap_err(), ParseError::UnexpectedToken("@".to_string()));
-}
-
 // Parses an incomplete expression and returns an error
 #[test]
 fn test_parse_expression_missing_token_at_end() {


### PR DESCRIPTION
I have added unit tests for `lexer` and `parser`. 

UTF-8 is now supported for variable names.

**Issues resolved**
#20 
#21 
#22 
#23 (Closed due to irrelevance)
#28 
