### PR TITLE
Variables, constants, and clear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,256 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clearscreen"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41dc435a7b98e4608224bbf65282309f5403719df9113621b30f8b6f74e2f4"
+dependencies = [
+ "nix",
+ "terminfo",
+ "thiserror",
+ "which",
+ "windows-sys",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "terminal-calculator"
-version = "0.5.0"
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "terminal-calculator"
+version = "0.8.0"
+dependencies = [
+ "clearscreen",
  "libm",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -21,3 +260,94 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-calculator"
-version = "0.5.0"
+version = "0.8.0"
 edition = "2024"
 
 [[bin]]
@@ -8,5 +8,6 @@ name = "calc"
 path = "src/main.rs"
 
 [dependencies]
+clearscreen = "4.0.1"
 libm = "0.2.15"
 unicode-ident = "1.0.18"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,8 @@ pub enum EvaluationError {
     InvalidOperation,
     NotAFunction,
     Undefined,
+    CannotAssignAConstant(String),
+    UndefinedVariable(String)
     // InvalidInput,
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,5 +1,47 @@
 use crate::parser::AstNode;
-use crate::errors::EvaluationError;
+use crate::errors::{EvaluationError};
+use std::collections::HashMap;
+
+pub struct Environment {
+    variables: HashMap<String, f64>,
+}
+
+pub enum EvalResult {
+    Value(f64),
+    Assignment(String, f64),
+    Error(EvaluationError),
+}
+
+pub const CONSTS: [&str; 6] = ["pi", "e", "phi", "tau", "sqrt2", "sqrt3"];
+
+impl Environment {
+    pub fn new() -> Self {
+        Environment {
+            variables: HashMap::new(),
+        }
+    }
+
+    pub fn set_variable(&mut self, name: String, value: f64) -> Option<EvaluationError> {
+        if CONSTS.contains(&name.as_str()) {
+            return Some(EvaluationError::CannotAssignAConstant(name));
+        }
+        self.variables.insert(name, value);
+        return None;
+    }
+
+    pub fn get_variable(&self, name: &str) -> Option<&f64> {
+        self.variables.get(name)
+    }
+
+    pub fn init_consts(&mut self) {
+        self.variables.insert("pi".to_string(), std::f64::consts::PI);
+        self.variables.insert("e".to_string(), std::f64::consts::E);
+        self.variables.insert("phi".to_string(), 1.618033988749895);
+        self.variables.insert("tau".to_string(), std::f64::consts::TAU);
+        self.variables.insert("sqrt2".to_string(), 1.4142135623730951);
+        self.variables.insert("sqrt3".to_string(), 1.7320508075688772);
+    }
+}
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum Function {
@@ -9,45 +51,67 @@ pub enum Function {
 }
 
 impl AstNode {
-    pub fn evaluate(&self) -> Result<f64, EvaluationError> {
+    pub fn evaluate(&self, environment: &mut Environment) -> EvalResult {
         match self {
-            AstNode::Number(value) => Ok(*value),
+            AstNode::Number(value) => EvalResult::Value(*value),
             AstNode::UnaryOp {operator, operand} => {
-                let a: f64 = match operand.evaluate() {
-                    Ok(result) => result,
-                    Err(error) => return Err(error),
+                let a: f64 = match operand.evaluate(environment) {
+                    EvalResult::Value(result) => result,
+                    EvalResult::Assignment(name, value) => return EvalResult::Assignment(name, value),
+                    EvalResult::Error(error) => return EvalResult::Error(error),
                 };
 
                 match operator.apply_unary(a) {
-                    Ok(result) => Ok(result),
-                    Err(error) => Err(error),
+                    Ok(result) => EvalResult::Value(result),
+                    Err(error) => EvalResult::Error(error),
                 }
             }
             AstNode::BinaryOp {operator, operand_1, operand_2} => {
-                let a: f64 = match operand_1.evaluate() {
-                    Ok(result) => result,
-                    Err(error) => return Err(error),
+                let a: f64 = match operand_1.evaluate(environment) {
+                    EvalResult::Value(result) => result,
+                    EvalResult::Assignment(name, value) => return EvalResult::Assignment(name, value),
+                    EvalResult::Error(error) => return EvalResult::Error(error),
                 };
 
-                let b: f64 = match operand_2.evaluate() {
-                    Ok(result) => result,
-                    Err(error) => return Err(error),
+                let b: f64 = match operand_2.evaluate(environment) {
+                    EvalResult::Value(result) => result,
+                    EvalResult::Assignment(name, value) => return EvalResult::Assignment(name, value),
+                    EvalResult::Error(error) => return EvalResult::Error(error),
                 };
 
                 match operator.apply_binary(a, b) {
-                    Ok(result) => Ok(result),
-                    Err(error) => Err(error),
+                    Ok(result) => EvalResult::Value(result),
+                    Err(error) => EvalResult::Error(error),
                 }
             }
             AstNode::Function {function, args} => {
-                let a: f64 = match args.evaluate() {
-                    Ok(result) => result,
-                    Err(error) => return Err(error),
+                let a: f64 = match args.evaluate(environment) {
+                    EvalResult::Value(result) => result,
+                    EvalResult::Assignment(name, value) => return EvalResult::Assignment(name, value),
+                    EvalResult::Error(error) => return EvalResult::Error(error),
                 };
                 
                 match function.apply_function(a) {
-                    Ok(result) => Ok(result),
-                    Err(error) => Err(error),
+                    Ok(result) => EvalResult::Value(result),
+                    Err(error) => EvalResult::Error(error),
+                }
+            }
+            AstNode::Assignment {name, value} => {
+                let a: f64 = match value.evaluate(environment) {
+                    EvalResult::Value(result) => result,
+                    EvalResult::Assignment(name, value) => return EvalResult::Assignment(name, value),
+                    EvalResult::Error(error) => return EvalResult::Error(error),
+                };
+                match environment.set_variable(name.clone(), a) {
+                    Some(error) => return EvalResult::Error(error),
+                    None => (),
+                };
+                EvalResult::Assignment(name.clone(), a)
+            }
+            AstNode::Variable(name) => {
+                match environment.get_variable(name) {
+                    Some(value) => EvalResult::Value(*value),
+                    None => EvalResult::Error(EvaluationError::UndefinedVariable(name.clone())),
                 }
             }
         }


### PR DESCRIPTION
Implemented variables. They are in an environment hash table: 
```rust
/* ===evaluator.rs=== */
pub struct Environment {
    variables: HashTable<String, f64>
};

/* ===main.rs=== */

let mut environment = Environment::new()
```

**New AstNodes**
 - `AstNode::Assignment(String, f64)`
 - `AstNode::Variable(String)`

**New error handling in `evaluator`**
`evaluator.rs` now uses an `EvalResult` enum to give errors. This is so I could add the `EvalResult::Assignment(String, f64)` variant, to prevent the REPL from printing the value of the assigned variable as a result.

Also, constants have been added, they are forced to lowercase in `lexer`, and checked against an array in `evaluator`.
